### PR TITLE
Fix: Correct portfolio turnover calculation

### DIFF
--- a/tests/test_portfolio_env.py
+++ b/tests/test_portfolio_env.py
@@ -1,0 +1,197 @@
+import numpy as np
+import pandas as pd
+import pytest
+from utils.portfolio_env import PortfolioEnv
+
+def create_mock_data(n_steps, n_assets, initial_price=100):
+    """
+    Helper function to create mock data for testing PortfolioEnv.
+    """
+    dates = pd.date_range(start='2023-01-01', periods=n_steps + 60) # Add buffer for window size
+
+    raw_returns = np.random.rand(n_steps + 60, n_assets) * 0.02 - 0.01 # Small positive/negative returns
+
+    # Ensure prices are positive
+    prices_list = []
+    current_prices = np.full(n_assets, initial_price)
+    for i in range(n_steps + 60):
+        prices_list.append(current_prices.copy())
+        current_prices = current_prices * (1 + raw_returns[i, :])
+        current_prices = np.maximum(current_prices, 1.0) # Ensure prices don't go to zero or negative
+
+    prices = pd.DataFrame(prices_list, columns=[f'asset_{i}' for i in range(n_assets)], index=dates)
+    returns = prices.pct_change().fillna(0)
+
+    # Make vol_df larger to cover all steps including window_size
+    vol = pd.DataFrame(np.random.rand(n_steps + 60, 3), columns=['vol1', 'vol2', 'vol3'], index=dates)
+
+    # Slice to actual n_steps for prices_df, but keep returns_df and vol_df aligned with it
+    # The environment uses .iloc[self.current_step] which can go up to len(returns_df) -1
+    # So returns_df, prices_df, vol_df should be of the same length
+    return returns, prices, vol
+
+def test_portfolio_turnover():
+    """
+    Tests the portfolio turnover calculation in PortfolioEnv.
+    """
+    n_assets = 2
+    window_size = 3 # Min window size for env due to vol_features slicing
+    num_test_steps = 3 # Number of actions to take
+
+    # We need enough data for window_size initialization and then num_test_steps
+    # The environment's current_step starts at window_size.
+    # If returns_df has length L, max current_step is L-1.
+    # We need L-1 to be >= window_size + num_test_steps -1
+    # So, L >= window_size + num_test_steps
+    total_data_steps = window_size + num_test_steps
+
+    returns_df, prices_df, vol_df = create_mock_data(n_steps=total_data_steps, n_assets=n_assets)
+
+    env = PortfolioEnv(
+        returns_df=returns_df,
+        prices_df=prices_df,
+        vol_df=vol_df,
+        window_size=window_size,
+        initial_balance=10000,
+        transaction_cost=0 # Simplify by not having transaction costs
+    )
+
+    # Reset env and get initial weights
+    obs, info = env.reset()
+    # After reset, env.weights are [0,0,...] for assets. Let's call this w0.
+    # env.weights_history is []. The step method will populate it.
+
+    actions = [
+        np.array([0.6, 0.4]), # Action for step 1 (target weights for rebalancing)
+        np.array([0.7, 0.3]), # Action for step 2
+        np.array([0.5, 0.5])  # Action for step 3
+    ]
+
+    # Store the sequence of actual weights applied for manual calculation
+    # w0 is the state after reset.
+    # In PortfolioEnv, weights are normalized by softmax.
+    # The actions here are pre-softmax. The env applies softmax.
+
+    # w0_actual = env.weights.copy() # These are all zeros for assets.
+    # This is not added to env.weights_history by reset(), but by the first step()
+
+    manual_weights_sequence = []
+    # The first element in env.weights_history (added by the first step)
+    # will be the initial weights (all zeros for assets).
+    # Let's capture the state of weights as they evolve.
+
+    # After reset, env.weights are the initial weights (e.g. [0,0] for assets).
+    manual_weights_sequence.append(env.weights.copy())
+
+
+    portfolio_values_history = [env.portfolio_value]
+    for i, raw_action in enumerate(actions):
+        # The env.step function applies softmax to raw_action
+        obs, reward, terminated, truncated, info = env.step(raw_action)
+        portfolio_values_history.append(info['portfolio_value'])
+        # env.weights now holds the weights *after* rebalancing based on raw_action
+        # This is w_i+1
+        manual_weights_sequence.append(env.weights.copy())
+
+    # manual_weights_sequence now contains [w0, w1, w2, w3]
+    # w0 = initial weights from reset
+    # w1 = weights after action 1 (softmax of raw_action[0])
+    # w2 = weights after action 2 (softmax of raw_action[1])
+    # w3 = weights after action 3 (softmax of raw_action[2])
+
+    # Let's verify what env.weights_history contains
+    # After 3 steps:
+    # step 1: history.append(w0_reset), env.weights = w1
+    # step 2: history.append(w1), env.weights = w2
+    # step 3: history.append(w2), env.weights = w3
+    # So env.weights_history = [w0_reset, w1, w2]
+    # And env.weights = w3
+    # The sequence for turnover should be [w0_reset, w1, w2, w3]
+    # This is exactly env.weights_history + [env.weights.copy()]
+
+    weights_for_calc = env.weights_history + [env.weights.copy()]
+
+    assert len(weights_for_calc) == num_test_steps + 1
+    assert np.array_equal(weights_for_calc[0], manual_weights_sequence[0]), "Mismatch in w0"
+    assert np.array_equal(weights_for_calc[1], manual_weights_sequence[1]), "Mismatch in w1"
+    assert np.array_equal(weights_for_calc[2], manual_weights_sequence[2]), "Mismatch in w2"
+    assert np.array_equal(weights_for_calc[3], manual_weights_sequence[3]), "Mismatch in w3"
+
+
+    # Manually calculate expected turnover
+    # W = manual_weights_sequence = [w0, w1, w2, w3]
+    # turnover = (sum(|w1-w0|) + sum(|w2-w1|) + sum(|w3-w2|)) / 3
+
+    expected_turnover_sum = 0
+    for i in range(1, len(manual_weights_sequence)):
+        # Sum of absolute differences for each asset
+        # weights are for assets only, cash is handled by w_c = 1 - sum(weights)
+        # The turnover formula np.sum(np.abs(np.diff(np.array(weights_history), axis=0)))
+        # considers all elements in the weight vectors. If cash is not part of these vectors,
+        # its change is implicitly captured if asset weights change.
+        # The weights in PortfolioEnv.weights are only for assets.
+        diff = np.abs(manual_weights_sequence[i] - manual_weights_sequence[i-1])
+        expected_turnover_sum += np.sum(diff)
+
+    if num_test_steps > 0:
+        expected_turnover = expected_turnover_sum / num_test_steps
+    else:
+        expected_turnover = np.nan # Or 0, consistent with env's calc_metrics
+
+    metrics = env.calc_metrics(
+        portfolio_values=np.array(portfolio_values_history),
+        weights_history=weights_for_calc
+    )
+    calculated_turnover = metrics["Portfolio turnover"]
+
+    if num_test_steps == 0:
+        assert np.isnan(calculated_turnover), "Turnover should be NaN for no rebalancing periods"
+    else:
+        assert np.isclose(calculated_turnover, expected_turnover), \
+            f"Calculated turnover {calculated_turnover} does not match expected {expected_turnover}"
+
+def test_portfolio_turnover_no_steps():
+    """
+    Tests turnover calculation when there are no actual rebalancing steps, or only initial state.
+    """
+    n_assets = 2
+    window_size = 3 # Min window size for env
+    total_data_steps = window_size + 0 # No test steps beyond initialization
+
+    returns_df, prices_df, vol_df = create_mock_data(n_steps=total_data_steps, n_assets=n_assets)
+    env = PortfolioEnv(returns_df, prices_df, vol_df, window_size=window_size)
+
+    obs, info = env.reset()
+
+    # weights_history in calc_metrics will be env.weights_history + [env.weights.copy()]
+    # After reset, env.weights_history is [], env.weights is [0,0]
+    # If we call calc_metrics immediately:
+    # final_weights_history = [env.weights.copy()] which is [[0,0]]
+    # np.diff on this will be empty. Turnover should be NaN.
+    metrics_initial = env.calc_metrics(
+        portfolio_values=np.array([env.initial_balance, env.portfolio_value]), # dummy PV history
+        weights_history=[env.weights.copy()] # Only initial weights
+    )
+    assert np.isnan(metrics_initial["Portfolio turnover"]), "Turnover should be NaN with only one set of weights"
+
+    # If we take one step:
+    # env.reset() -> w0 = [0,0], hist=[]
+    # env.step(a1) -> hist=[w0], env.weights=w1
+    # final_weights_history for calc_metrics = [w0, w1]
+    # Turnover = sum(|w1-w0|) / 1
+    obs, reward, terminated, truncated, info = env.step(np.array([0.5, 0.5]))
+
+    final_weights_one_step = env.weights_history + [env.weights.copy()] # Should be [w0, w1]
+    assert len(final_weights_one_step) == 2
+
+    expected_turnover_one_step = np.sum(np.abs(final_weights_one_step[1] - final_weights_one_step[0])) / 1.0
+
+    metrics_one_step = env.calc_metrics(
+        portfolio_values=np.array([env.initial_balance, env.portfolio_value, env.portfolio_value + 100]), # dummy
+        weights_history=final_weights_one_step
+    )
+    assert np.isclose(metrics_one_step["Portfolio turnover"], expected_turnover_one_step)
+
+# pytest.main() # For running with `python tests/test_portfolio_env.py`
+# To run with pytest CLI, remove pytest.main() and just run `pytest` from root.
+# For now, keeping it to allow direct execution.

--- a/utils/drl_agent.py
+++ b/utils/drl_agent.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from stable_baselines3 import PPO
-from stable_baselines3.common.vec_env import SubprocVecEnv
+from stable_baselines3.common.vec_env import SubprocVecEnv, VecEnv
 from stable_baselines3.common.utils import set_random_seed
 
 # from stable_baselines3.common.callbacks import BaseCallback
@@ -205,6 +205,7 @@ class DRLAgent:
             Dictionary containing evaluation metrics
         """
         all_portfolio_values = []
+        all_weights_history = [] # Initialize history for all episodes
         rewards = []
 
         for episode in range(n_episodes):
@@ -212,27 +213,78 @@ class DRLAgent:
             done = False
             total_reward = 0.0
             episode_portfolio_values = []
+            episode_weights_history = [] # Initialize history for current episode
+
+            # Add initial weights at the beginning of the episode
+            if isinstance(env, VecEnv):
+                initial_weights = env.env_method('get_current_weights')[0]
+            else:
+                initial_weights = env.get_current_weights()
+            episode_weights_history.append(initial_weights)
 
             while not done:
                 action = self.predict(obs)
-                obs, reward, terminated, truncated, info = env.step(action)
+                obs, reward, terminated, truncated, info_step = env.step(action) # Renamed info to info_step
                 total_reward += reward
-                done = terminated or truncated
+                done = terminated or truncated # Assuming terminated and truncated are booleans or arrays of booleans
 
-                if "portfolio_value" in info:
-                    episode_portfolio_values.append(info["portfolio_value"])
+                # Handle info_step for VecEnv
+                current_info = info_step[0] if isinstance(env, VecEnv) else info_step
+
+                if "portfolio_value" in current_info:
+                    episode_portfolio_values.append(current_info["portfolio_value"])
+
+                # Get current weights
+                if isinstance(env, VecEnv):
+                    current_weights = env.env_method('get_current_weights')[0]
+                else:
+                    current_weights = env.get_current_weights()
+                episode_weights_history.append(current_weights)
 
             rewards.append(total_reward)
+            # For VecEnv, all_portfolio_values might need specific handling if episodes end at different times.
+            # Here, assuming episodes run full length or portfolio_values are handled correctly by the env.
+            # If env is VecEnv, episode_portfolio_values will actually be from the first sub-env.
             all_portfolio_values.extend(episode_portfolio_values)
+            if n_episodes > 0: # This check is technically not needed due to loop condition
+                all_weights_history.append(episode_weights_history)
 
-        # Calculate evaluation metrics using agent's method
-        eval_metrics = self.calc_metrics(all_portfolio_values)
-        eval_metrics["Average Reward"] = np.mean(rewards)
+        # Determine weights_history for calc_metrics
+        eval_weights_history = None
+        if all_weights_history:
+            eval_weights_history = all_weights_history[0] # Use weights from the first episode
+
+        # Calculate evaluation metrics using the environment's method
+        if isinstance(env, VecEnv):
+            # Assuming all sub-environments in VecEnv have similar portfolio_values patterns for evaluation
+            # For simplicity, we use portfolio_values from the first sub-env if it's a VecEnv.
+            # A more robust approach might involve averaging metrics across sub-envs or handling them individually.
+            # However, standard evaluation usually runs on a single env instance.
+            # If all_portfolio_values were collected from VecEnv (e.g. info[0]), it's already from the first env.
+            metrics_env = env.envs[0] # Get the actual environment instance for calc_metrics
+            eval_metrics = metrics_env.calc_metrics(
+                portfolio_values=np.array(all_portfolio_values) if all_portfolio_values else np.array([env.envs[0].initial_balance]),
+                weights_history=eval_weights_history
+            )
+        else:
+            eval_metrics = env.calc_metrics(
+                portfolio_values=np.array(all_portfolio_values) if all_portfolio_values else np.array([env.initial_balance]),
+                weights_history=eval_weights_history
+            )
+
+        # Ensure rewards is not empty before calculating mean
+        if rewards:
+            eval_metrics["Average Reward"] = np.mean(rewards)
+        else:
+            eval_metrics["Average Reward"] = np.nan
+
 
         # Print evaluation summary
+        final_pv = all_portfolio_values[-1] if all_portfolio_values else (env.envs[0].initial_balance if isinstance(env, VecEnv) else env.initial_balance)
         print("\nEvaluation Summary:")
-        print(f"Final Portfolio Value: ${all_portfolio_values[-1]:,.2f}")
-        print(f"Average Reward: {np.mean(rewards):.4f}")
+        print(f"Final Portfolio Value: ${final_pv:,.2f}")
+        avg_reward_val = np.mean(rewards) if rewards else np.nan
+        print(f"Average Reward: {avg_reward_val:.4f}")
         print("\nPerformance Metrics:")
         for metric, value in eval_metrics.items():
             if isinstance(value, float):

--- a/utils/portfolio_env.py
+++ b/utils/portfolio_env.py
@@ -88,6 +88,7 @@ class PortfolioEnv(gym.Env):
         # Initialize weights and cash weight
         self.weights = np.zeros(self.n_assets, dtype=np.float32)
         self.w_c = 1.0
+        self.weights_history = []
 
         # Initialize state
         self.reset()
@@ -118,6 +119,7 @@ class PortfolioEnv(gym.Env):
         self.prev_A_t = 0.0
         self.prev_B_t = 0.0
         self.prev_sharpe = 0.0
+        self.weights_history = []
         return self._get_observation(), {}
 
     def step(self, action: np.ndarray) -> Tuple[np.ndarray, float, bool, bool, Dict]:
@@ -169,6 +171,8 @@ class PortfolioEnv(gym.Env):
         }
 
         # Update weights and cash weight for next round using previous (t-1) prices
+        self.weights_history.append(self.weights.copy())
+        self.previous_weights = self.weights.copy()
         self.weights = np.array(
             [
                 shares[t] * prev_prices[t] / self.portfolio_value
@@ -339,6 +343,7 @@ class PortfolioEnv(gym.Env):
         self,
         portfolio_values: Union[List[float], np.ndarray, pd.Series],
         risk_free_rate: float = 0.02,
+        weights_history: Optional[List[np.ndarray]] = None,
     ):
         """
         Calculate various portfolio performance metrics.
@@ -346,6 +351,8 @@ class PortfolioEnv(gym.Env):
         Args:
             portfolio_values: Array of portfolio values over time
             risk_free_rate: Annual risk-free rate (default: 2%)
+            weights_history: Optional list of portfolio weights history.
+                             If None, uses self.weights_history.
 
         Returns:
             Dictionary containing various portfolio metrics
@@ -356,6 +363,16 @@ class PortfolioEnv(gym.Env):
 
         # Calculate daily returns
         daily_returns = np.diff(portfolio_values) / portfolio_values[:-1]
+
+        # Use provided weights_history or internal one
+        if weights_history is None:
+            weights_history = self.weights_history
+
+        # Calculate portfolio turnover
+        if weights_history and len(weights_history) > 1:
+            turnover = np.sum(np.abs(np.diff(np.array(weights_history), axis=0))) / (len(weights_history) -1)
+        else:
+            turnover = np.nan
 
         # Annual return (assuming 252 trading days)
         annual_return = (portfolio_values[-1] / portfolio_values[0]) ** (
@@ -411,8 +428,8 @@ class PortfolioEnv(gym.Env):
         # Value at Risk (95%)
         var = np.percentile(daily_returns, 5)
 
-        # Portfolio turnover (average daily change in weights)
-        daily_change = np.mean(
+        # Mean absolute daily return
+        mean_daily_return_abs = np.mean(
             np.abs(np.diff(portfolio_values) / portfolio_values[:-1])
         )
 
@@ -433,5 +450,12 @@ class PortfolioEnv(gym.Env):
             "Kurtosis": kurtosis,
             "Tail ratio": tail_ratio,
             "Daily value at risk": var,
-            "Portfolio turnover": daily_change,
+            "Portfolio turnover": turnover,
+            "Mean daily return abs": mean_daily_return_abs,
         }
+
+    def get_current_weights(self) -> np.ndarray:
+        """
+        Returns a copy of the current portfolio weights.
+        """
+        return self.weights.copy()


### PR DESCRIPTION
The portfolio turnover metric was previously calculated as the mean absolute daily change in portfolio value, resulting in incorrect NaN values or misleading figures.

This commit addresses the issue by:
1. Modifying `PortfolioEnv` in `utils/portfolio_env.py`:
    - Storing the history of portfolio asset weights (`self.weights_history`).
    - Updating the `calc_metrics` method to compute portfolio turnover correctly using the sum of absolute changes in asset weights across rebalancing periods, normalized by the number of periods.
    - Renaming the previous incorrect "Portfolio turnover" metric to "Mean daily return abs" for clarity.
2. Updating `DRLAgent.evaluate` in `utils/drl_agent.py`:
    - Ensuring that the history of portfolio weights from evaluation episodes is collected and passed to the `calc_metrics` method of the environment.
    - Added a `get_current_weights` method to `PortfolioEnv` to facilitate this.
3. Adding unit tests in `tests/test_portfolio_env.py`:
    - New tests verify the correctness of the portfolio turnover calculation under various scenarios, including typical multi-step rebalancing and edge cases with fewer steps.

The portfolio turnover metric should now provide an accurate measure of trading activity.