### PR TITLE
Fix: Address agent cloning in sliding windows and improve logging

### DIFF
--- a/notebooks/drl_train_sliding_window_jules.ipynb
+++ b/notebooks/drl_train_sliding_window_jules.ipynb
@@ -24,6 +24,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TensorBoard Logging\n",
+    "\n",
+    "This notebook logs training progress using TensorBoard. Logs for each agent and window will be saved in subdirectories within the `../tensorboard_logs/` directory (relative to this notebook's location).\n",
+    "\n",
+    "To view the logs:\n",
+    "1. Open a terminal or command prompt.\n",
+    "2. Navigate to the directory *containing* the `tensorboard_logs` directory (i.e., the root of this repository if you are running the notebook from the `notebooks` folder).\n",
+    "3. Run the command: `tensorboard --logdir tensorboard_logs/`\n",
+    "4. Open the URL provided by TensorBoard (usually http://localhost:6006/) in your web browser.\n",
+    "\n",
+    "You should see experiments named like `PPO_WindowX_AgentY_SeedZ`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
@@ -39,9 +56,11 @@
     "RETURNS_DATA_PATH = \"../data/returns.parquet\"\n",
     "VOLA_DATA_PATH = \"../data/vola.parquet\"\n",
     "MODEL_SAVE_DIR = \"../models/sliding_window_jules/\"\n",
+    "TENSORBOARD_LOG_DIR = \"../tensorboard_logs/\" # Directory for TensorBoard logs\n",
     "\n",
     "# Ensure model save directory exists\n",
     "os.makedirs(MODEL_SAVE_DIR, exist_ok=True)\n",
+    "os.makedirs(TENSORBOARD_LOG_DIR, exist_ok=True)\n",
     "\n",
     "# --- DRL Agent Hyperparameters (from paper) ---\n",
     "N_ENVS = 10\n",
@@ -3091,6 +3110,7 @@
     "            # DRLAgent's load_from_file uses its internal self.env by default if env=None.\n",
     "            # This self.env is already configured with N_ENVS and the new train_data.\n",
     "            agent.load_from_file(path=previous_best_agent_path, env=None) \n",
+    "            agent.model.set_random_seed(agent_seed) # Ensure the loaded model uses the new agent_seed\n",
     "                                   \n",
     "        # Train the agent\n",
     "        print(f\"    Starting training for {TOTAL_TIMESTEPS_PER_ROUND} timesteps...\")\n",
@@ -3098,7 +3118,8 @@
     "        # Example: agent.train(total_timesteps=10000, tb_log_name=f\"ppo_win{i_window}_agent{i_agent}\")\n",
     "        agent.train(\n",
     "            total_timesteps=TOTAL_TIMESTEPS_PER_ROUND, \n",
-    "            tb_log_name=f\"PPO_Window{i_window+1}_Agent{i_agent+1}_Seed{agent_seed}\"\n",
+    "            tb_experiment_name=f\"PPO_Window{i_window+1}_Agent{i_agent+1}_Seed{agent_seed}\",\n",
+    "            tensorboard_log_path=TENSORBOARD_LOG_DIR\n",
     "        )\n",
     "        \n",
     "        # Evaluate the agent on the validation set\n",

--- a/utils/drl_agent_jules.py
+++ b/utils/drl_agent_jules.py
@@ -83,12 +83,12 @@ class DRLAgent:
         )
         self.training_metrics = None
 
-    def train(self, total_timesteps: int = 100_000, tb_log_name: str = "ppo"):
+    def train(self, total_timesteps: int = 100_000, tb_experiment_name: str = "ppo", tensorboard_log_path: str = "./tensorboard_logs/"):
         self.model.learn(
-            total_timesteps=total_timesteps, progress_bar=True, tb_log_name=tb_log_name
+            total_timesteps=total_timesteps, progress_bar=True, tb_log_name=tb_experiment_name, tensorboard_log=tensorboard_log_path
         )
         print(f"\nTraining complete. Trained for {total_timesteps} timesteps.")
-        print(f"TensorBoard logs saved to directory: {tb_log_name}")
+        print(f"TensorBoard logs for experiment '{tb_experiment_name}' saved in directory: {tensorboard_log_path}")
 
     def predict(self, obs: np.ndarray, deterministic: bool = True):
         action, _ = self.model.predict(obs, deterministic=deterministic)


### PR DESCRIPTION
This commit introduces several changes to address issues in the DRL sliding window training process:

1.  **Resolve Agent Cloning (P1):** In `notebooks/drl_train_sliding_window_jules.ipynb`, after an agent model is loaded from the previous window's best performer, `agent.model.set_random_seed(agent_seed)` is now called. This ensures that each agent in the new window, despite starting from the same network weights, will operate with a different random seed for its training process and environment interactions. This should promote diversity in learned policies among agents within the same window.

2.  **Standardize TensorBoard Log Output (P3):** The `train` method in `utils/drl_agent_jules.py` has been updated to accept an explicit `tensorboard_log_path` and `tb_experiment_name`. This makes log storage more predictable. The training notebook has been updated to use a dedicated `../tensorboard_logs/` directory.

3.  **Improve Training Progress Visibility (P4):** A markdown cell has been added to `notebooks/drl_train_sliding_window_jules.ipynb` instructing you on how to locate the TensorBoard logs and launch TensorBoard for monitoring training progress.

Note: Verification of the P1 fix through a test run was not possible due to an execution environment error ("No space left on device"). The fix relies on the expected behavior of `set_random_seed`.